### PR TITLE
Refactor WhoAmI list to be tracked using schemas

### DIFF
--- a/DeviceWhoAmI.json
+++ b/DeviceWhoAmI.json
@@ -1,0 +1,41 @@
+{
+    "$id": "http://https://github.com/harp-tech/protocol/DeviceWhoAmI.json",
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "definitions": {
+        "device": {
+            "properties": {
+                "contributor": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
+                },
+
+                "organization": {
+                    "type": "string"
+                },
+                "projectWebsite": {
+                    "type": "string"
+                },
+                "sourceRepository": {
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "devices": {
+            "description": "A map of device WhoAmI to device information",
+            "patternProperties": {
+                "^[1-9][0-9][0-9]|[1-9][0-9][0-9][0-9]$": {
+                    "$ref": "#/definitions/device"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "title": "DeviceWhoAmI"
+}

--- a/DeviceWhoAmI.yml
+++ b/DeviceWhoAmI.yml
@@ -1,0 +1,139 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=./DeviceWhoAmI.json
+
+devices:
+  256:
+    name: USBHub
+  1024:
+    name: Poke
+  1040: &harptechdevice
+    name: MultiPwmGenerator
+    contributor: harp-tech
+    organization: harp-tech
+    sourceRepository: https://github.com/harp-tech/device.multipwm
+    projectWebsite: https://github.com/harp-tech/device.multipwm
+  1056:
+    name: Wear
+  1058:
+    <<: *harptechdevice
+    name: WearBaseStationGen2
+    sourceRepository: https://github.com/harp-tech/harp_wear_basestation_v2
+    projectWebsite: https://github.com/harp-tech/harp_wear_basestation_v2
+  1072:
+    name: Driver12Volts
+  1088:
+    name: LedController
+  1104:
+    <<: *harptechdevice
+    name: Synchronizer
+    sourceRepository: https://github.com/harp-tech/device.synchronizer
+    projectWebsite: https://github.com/harp-tech/device.inputexpander
+  1106:
+    <<: *harptechdevice
+    name: InputExpander
+    sourceRepository: https://github.com/harp-tech/device.inputexpander
+    projectWebsite: https://github.com/harp-tech/device.inputexpander
+  1108:
+    <<: *harptechdevice
+    name: OutputExpander
+    sourceRepository: https://github.com/harp-tech/device.outputexpander
+    projectWebsite: https://github.com/harp-tech/device.outputexpander
+  1121:
+    name: SimpleAnalogGenerator
+  1136:
+    name: Archimedes
+  1140:
+    name: Olfactometer
+  1152:
+    <<: *harptechdevice
+    name: ClockSynchronizer
+    sourceRepository: https://github.com/harp-tech/device.clocksync
+    projectWebsite: https://github.com/harp-tech/device.clocksync
+  1154:
+    <<: *harptechdevice
+    name: TimestampGeneratorGen1
+    sourceRepository: https://github.com/harp-tech/harp_timestamp_generator_Gen1
+    projectWebsite: https://github.com/harp-tech/harp_timestamp_generator_Gen1
+  1158:
+    <<: *harptechdevice
+    name: TimestampGeneratorGen3
+    sourceRepository: https://github.com/harp-tech/device.timestampgeneratorgen3
+    projectWebsite: https://github.com/harp-tech/device.timestampgeneratorgen3
+  1168:
+    <<: *harptechdevice
+    name: CameraTriggerControl
+    sourceRepository: https://github.com/harp-tech/device.cameratriggercontrol
+    projectWebsite: https://github.com/harp-tech/device.cameratriggercontrol
+  1170:
+    <<: *harptechdevice
+    name: CameraController
+    sourceRepository: https://github.com/harp-tech/device.cameracontroller
+    projectWebsite: https://github.com/harp-tech/device.cameracontroller
+  1184:
+    name: PyControlAdapter
+  1216:
+    <<: *harptechdevice
+    name: Behavior
+    sourceRepository: https://github.com/harp-tech/device.behavior
+    projectWebsite: https://github.com/harp-tech/device.behavior
+  1224:
+    name: VestibularH1
+    contributor: NeuroGEARS
+    organization: NeuroGEARS
+    sourceRepository: https://github.com/neurogears/device.vestibularH1
+    projectWebsite: https://github.com/neurogears/device.vestibularH1
+  1225:
+    name: VestibularH2
+    contributor: NeuroGEARS
+    organization: NeuroGEARS
+    sourceRepository: https://github.com/neurogears/device.vestibularH2
+    projectWebsite: https://github.com/neurogears/device.vestibularH2
+  1232:
+    <<: *harptechdevice
+    name: LoadCells
+    sourceRepository: https://github.com/harp-tech/device.loadcells
+    projectWebsite: https://github.com/harp-tech/device.loadcells
+  1236:
+    <<: *harptechdevice
+    name: AnalogInput
+    sourceRepository: https://github.com/harp-tech/device.analoginput
+    projectWebsite: https://github.com/harp-tech/device.analoginput
+  1248:
+    <<: *harptechdevice
+    name: RgbArray
+    sourceRepository: https://github.com/harp-tech/device.rgbarray
+    projectWebsite: https://github.com/harp-tech/device.rgbarray
+  1200:
+    name: FlyPad
+  1280:
+    <<: *harptechdevice
+    name: SoundCard
+    sourceRepository: https://github.com/harp-tech/device.soundcard
+    projectWebsite: https://github.com/harp-tech/device.soundcard
+  1296:
+    <<: *harptechdevice
+    name: SyringePump
+    sourceRepository: https://github.com/harp-tech/device.syringepump
+    projectWebsite: https://github.com/harp-tech/device.syringepump
+  2064:
+    name: NeurophotometricsFP3002
+    organization: Neurophotometrics
+    sourceRepository: https://github.com/neurophotometrics/neurophotometrics
+    projectWebsite: https://github.com/neurophotometrics/neurophotometrics
+  2080:
+    <<: *harptechdevice
+    name: Ibl_behavior_control
+    sourceRepository: https://github.com/harp-tech/IBL_behavior_control
+    projectWebsite: https://github.com/harp-tech/IBL_behavior_control
+  2094:
+    <<: *harptechdevice
+    name: RfidReader
+    sourceRepository: https://github.com/harp-tech/device.rfidreader
+    projectWebsite: https://github.com/harp-tech/device.rfidreader
+  2110:
+    name: Pluma
+    contributor: NeuroGEARS
+    organization: EmotionalCities
+    sourceRepository: https://github.com/emotional-cities/pluma
+    projectWebsite: https://github.com/emotional-cities/pluma

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Harp technology was originally thought at Champalimaud Foundation to suppres
 
 ## List of the current devices' IDs reported
 
-A list of currently reserved `WhoAmI` identifiers is available in the [`DeviceWhoAmI.yml`](./DeviceWhoAmI.yml) file.
+A list of currently reserved `WhoAmI` identifiers is available in the [`DeviceWhoAmI.yml`](./DeviceWhoAmI.yml) file. If you want to add reserve a new device, please submit a Pull Request with the desired address to this file. Make sure you include a description of the device in the PR along with a source and project website, if applicable.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -5,41 +5,7 @@ The Harp technology was originally thought at Champalimaud Foundation to suppres
 
 ## List of the current devices' IDs reported
 
-| ID | Device |
-|:---:|:---|
-| 256 | USB Hub |
-| 1024 | Poke |
-| 1040 | Multi Pwm Generator |
-| 1056 | Wear |
-| 1058 | Wear Basestation Gen2 |
-| 1072 | 12 Volts Drive |
-| 1088 | Led Controller |
-| 1104 | Synchronizer |
-| 1106 | Input Expander |
-| 1108 | Output Expander |
-| 1121 | Simple Analog Generator |
-| 1136 | Archimedes |
-| 1140 | Olfactometer |
-| 1152 | Clock Synchronizer |
-| 1154 | Timestamp Generator Gen1 |
-| 1158 | Timestamp Generator Gen3 |
-| 1168 | Camera Controller |
-| 1170 | Camera Controller Gen2 |
-| 1184 | PyControl Adapter |
-| 1216 | Behavior |
-| 1224 | Vestibular VR H1 |
-| 1225 | Vestibular VR H2 |
-| 1232 | Load Cells Reader |
-| 1236 | Analog Input |
-| 1248 | Audio Switch |
-| 1264 | Rgbs |
-| 1200 | FlyPad |
-| 1280 | Sound Card |
-| 1296 | Pump |
-| 2064 | Neurophotometrics FP3002 |
-| 2080 | IBL Behavior Control |
-| 2094 | RFID Reader |
-| 2110 | BioReader |
+A list of currently reserved `WhoAmI` identifiers is available in the [`DeviceWhoAmI.yml`](./DeviceWhoAmI.yml) file.
 
 ## Licensing
 


### PR DESCRIPTION
This PR tries to make the WhoAmI reservation process more systematic.
First, a JSON schema was written to ensure the list follows a stable format and, critically, guarantees that no two devices share the same address (The key used in the schema, which must be unique). 

Second, a `.yml` file was added to keep track of all current and future devices using this schema.


I suggest that, in the future, when addresses are to be reserved, a Pull Request modifying this file should be made and the evaluation process can take place in the respective PR discussion. Successful merge of the PR will result in the WhoAmI address reservation.