### PR TITLE
Reformat protocol markdown for integration in doc pages

### DIFF
--- a/BinaryProtocol-32bit.md
+++ b/BinaryProtocol-32bit.md
@@ -1,5 +1,6 @@
-# Binary Protocol 32-bit (v0.1)
 <img src="./Logo/HarpLogoSmall.svg" width="200">
+
+# Binary Protocol 32-bit (v0.1)
 
 ## Introduction
 

--- a/BinaryProtocol-8bit.md
+++ b/BinaryProtocol-8bit.md
@@ -8,13 +8,13 @@ The Harp Protocol is a binary communication protocol created in order to facilit
 
 The protocol is based on addresses. Each address points to a certain memory position available in the device. These positions are called registers. Each register is defined by a data type and some meaningful functionality attached to the data.
 
-The Harp Binary Protocol is commonly used for all exchanges between a Controller and a Device. The Controller can be a computer, or a server and the Device can be a data acquisition or actuator microcontroller.
+The Harp Binary Protocol is commonly used for all exchanges between a `Controller` and a `Device`. The controller can be a computer, or a server and the device can be a data acquisition or actuator microcontroller.
 
 The available packets are:
 
-* Command: Sent by the Controller to the Device. Command messages can be used to read or write the register contents.
-* Reply: Sent by the Device in response to a Command.
-* Event: Sent by the Device when an external or internal event of interest happens. An Event message will always carry the contents of the register that the event refers to.
+* `Command`: Sent by the Controller to the Device. Command messages can be used to read or write the register contents.
+* `Reply`: Sent by the Device in response to a Command.
+* `Event`: Sent by the Device when an external or internal event of interest happens. An Event message will always carry the contents of the register that the event refers to.
 
 > **Note**
 >
@@ -40,9 +40,9 @@ Specifies the type of the Harp Message.
 
 |   Value   |  Description  |
 | :-------  |  ----------- |
-| 1 (Read)  |  Read the content of the register with address [RegisterAddress]  |
-| 2 (Write) |   Write the content to the register with address [RegisterAddress]     |
-| 3 (Event) |   Send the content of the register with address [RegisterAddress]     |
+| 1 (`Read`)  |  Read the content of the register with address [`RegisterAddress`]  |
+| 2 (`Write`) |   Write the content to the register with address [`RegisterAddress`]     |
+| 3 (`Event`) |   Send the content of the register with address [`RegisterAddress`]     |
 
 ### Length (1 byte)
 
@@ -58,7 +58,7 @@ If the device is a Hub of Harp Devices, it indicates the origin or destination o
 
 ### PayloadType (1 byte)
 
-Indicates the type of data available on the [Payload].
+Indicates the type of data available on the [`Payload`].
 The structure of this byte follows the following specification:
 
 <table>
@@ -83,7 +83,7 @@ The structure of this byte follows the following specification:
 
 #### Type (4 bits)
 
-Specifies the size of the word in the [Payload].
+Specifies the size of the word in the [`Payload`].
 
 |  Value  |  Description  |
 | :-----: |  -----------: |
@@ -94,40 +94,40 @@ Specifies the size of the word in the [Payload].
 
 #### HasTimestamp (1 bit)
 
-If this bit is set the Harp Message contains a timestamp. In this case the fields [Seconds] and [Microseconds] must be present in the message.
+If this bit is set the Harp Message contains a timestamp. In this case the fields [`Seconds`] and [`Microseconds`] must be present in the message.
 
 #### IsFloat (1 bit)
 
-This bit indicates whether the [Payload] represents fractional values. If the bit is not set, the payload contains integers.
+This bit indicates whether the [`Payload`] represents fractional values. If the bit is not set, the payload contains integers.
 
 #### IsSigned (1 bit)
 
-If the bit is set, indicates that the [Payload] contains integers with signal.
+If the bit is set, indicates that the [`Payload`] contains integers with signal.
 
 > **Note**
 >
-> The bits [IsFloat] and [IsSigned] must never be set simultaneously.
+> The bits [`IsFloat`] and [`IsSigned`] must never be set simultaneously.
 
 ### Payload (? bytes)
 
 The content of the Harp Message.
 
-If the [HasTimestamp] flag is set, the following optional fields are present at the beginning of the message payload:
+If the [`HasTimestamp`] flag is set, the following optional fields are present at the beginning of the message payload:
 
 #### Seconds (4 bytes)
 
-Contains the number of seconds (`U32`) of the Harp Timestamp clock. This field is optional. In order to indicate that this field is available, the bit [HasTimestamp] in the field [PayloadType] needs to be set.
+Contains the number of seconds (`U32`) of the Harp Timestamp clock. This field is optional. In order to indicate that this field is available, the bit [`HasTimestamp`] in the field [`PayloadType`] needs to be set.
 
 #### Microseconds (2 bytes)
 
 It contains the fractional part of the Harp Timestamp clock in microseconds (`U16` containing the number of microseconds divided by 32).
 
-This field is optional. In order to indicate that this field is available, the bit [HasTimestamp] in the field [PayloadType] needs to be set.
+This field is optional. In order to indicate that this field is available, the bit [`HasTimestamp`] in the field [`PayloadType`] needs to be set.
 
 > **Note**
 >
 > The full timestamp information can thus be retrieved using the formula:
-> Timestamp(s) = [Seconds] + [Microseconds] * 32 * 10-6
+> Timestamp(s) = [`Seconds`] + [`Microseconds`] * 32 * 10-6
 
 ### Checksum (1 byte)
 
@@ -142,12 +142,12 @@ Some of the fields described on the previous chapter have special features. Thes
 
 ### MessageType and ErrorFlag
 
-The field [Command] has an Error flag on the 4th least significant bit. When this bit is set it means that an error has occured.
+The field [`Command`] has an Error flag on the 4th least significant bit. When this bit is set it means that an error has occured.
 Examples of possible errors cane be:
 
-  1. The host tries to read from a register that doesn’t exist;
-  2. The host tries to write invalid data to a certain register;
-  3. The [PayloadType] doesn’t match the target register specification.
+  1. The controller tries to read from a register that doesn’t exist;
+  2. The controller tries to write invalid data to a certain register;
+  3. The [`PayloadType`] doesn’t match the target register specification.
 
 A simple code in C to check for error will be:
 
@@ -162,10 +162,10 @@ A simple code in C to check for error will be:
 
 ### Harp Message Length
 
-If one byte is not enough to express the length of the Harp Message, use [Length] equal to 255 and add after an unsigned 16 bits word with the Harp Message length.
+If one byte is not enough to express the length of the Harp Message, use [`Length`] equal to 255 and add after an unsigned 16 bits word with the Harp Message length.
 
-Replace the [Length] with:
-    [255] (1 byte) [ExtendedLength] (2 bytes)
+Replace the [`Length`] with:
+    [255] (1 byte) [`ExtendedLength`] (2 bytes)
 
 ### Parsing PayloadType
 
@@ -203,7 +203,7 @@ Note that the time information can appear without an element Timestamp<>.
   }
 ```
 
-The field `PayloadType` has a flag on the 5th least significant bit that indicates if the time information is available on the Harp Message. The existence of this flag is useful to know if the fields [Seconds] and [Microseconds] are present on the Harp Message.
+The field `PayloadType` has a flag on the 5th least significant bit that indicates if the time information is available on the Harp Message. The existence of this flag is useful to know if the fields [`Seconds`] and [`Microseconds`] are present on the Harp Message.
 In `C` one can check if the time information is avaible by using the following snippet:
 
 ```C
@@ -217,8 +217,8 @@ if (PayloadType &  hasTimestamp )
 
 ### Using Checksum to validate communication integrity
 
-The [Checksum] field is the sum of all bytes contained in the Harp Message. The receiver of the message should calculate the checksum and compare it with the received. If they don’t match, the Harp Message should be discarded.
-Example on how to calculate the [Checksum] in C language:
+The [`Checksum`] field is the sum of all bytes contained in the Harp Message. The receiver of the message should calculate the checksum and compare it with the received. If they don’t match, the Harp Message should be discarded.
+Example on how to calculate the [`Checksum`] in C language:
 
 ```C
 unsigned char Checksum = 0;
@@ -231,7 +231,7 @@ for (; i < Length + 1; i++ )
 
 ### Parsing [Payload] with Arrays
 
-The [Payload] element can contain a single, or an array of values of the same type. The first step to parse these payloads is to first find the number of values contained on the [Payload] element. This can be done using the following `C` code example:
+The [`Payload`] element can contain a single, or an array of values of the same type. The first step to parse these payloads is to first find the number of values contained on the [`Payload`] element. This can be done using the following `C` code example:
 
 ```C
 int arrayLength;
@@ -255,19 +255,19 @@ else
 
 ### Commands
 
-The device that implements this Harp Protocol receives [Write] and [Read] commands from the host, and replies with a copy of the message, timestamped with the hardware time at which the command was applied.
+The device that implements this Harp Protocol receives `Write` and `Read` commands from the controller, and replies with a copy of the message, timestamped with the hardware time at which the command was applied.
 
-Some Harp Messages are shown below to demonstrate the typical usage of the protocol between a device and a host. Note that timestamp information is usually omitted in messages sent from the host to the device, since actions are expected to run as soon as possible.
+Some Harp Messages are shown below to demonstrate the typical usage of the protocol between a device and a controller. Note that timestamp information is usually omitted in messages sent from the controller to the device, since actions are expected to run as soon as possible.
 
 We will use the following abbreviations:
 
-- [CMD] is a Command (From the Host to the Device);
-- [RPL] is a Reply (From Device to the Host)
-- [EVT] is an Event. (A message sent from the Device to the Host without a command (*i.e.* request) from the Host)
+- [CMD] is a Command (From the Controller to the Device);
+- [RPL] is a Reply (From Device to the Controller)
+- [EVT] is an Event. (A message sent from the Device to the Controller without a command (*i.e.* request) from the Controller)
 
 #### Write Message
 
-- [CMD] **Host**:       `2`  `Length` `Address` `Port` `PayloadType` `T` `Checksum`
+- [CMD] **Controller**:       `2`  `Length` `Address` `Port` `PayloadType` `T` `Checksum`
 - [RPL] **Device**: `2`  `Length` `Address` `Port` `PayloadType` `Timestamp<T>` `Checksum`       OK
 - [RPL] **Device**: `10` `Length` `Address` `Port` `PayloadType` `Timestamp<T>` `Checksum`       ERROR
 
@@ -275,7 +275,7 @@ The timestamp information in the [RPL] represents the time when the register wit
 
 ### Read Message
 
-- [CMD] **Host**: `1` `4`      `Address` `Port` `PayloadType` `Checksum`
+- [CMD] **Controller**: `1` `4`      `Address` `Port` `PayloadType` `Checksum`
 - [RPL] **Device**: `1` `Length` `Address` `Port` `PayloadType` `Timestamp<T>` `Checksum`       OK
 - [RPL] **Device**: `9` `10`     `Address` `Port` `PayloadType` `Timestamp<T>` `Checksum`        ERROR
 
@@ -306,7 +306,7 @@ The timestamp information in [EVT] represents the time when the register with [A
     * Major release.
 
 - v1.1
-    * Corrected [PayloadType] list on page 2.
+    * Corrected [`PayloadType`] list on page 2.
 
 - v1.2
     * Changed device naming to Controller and Peripheral.
@@ -322,5 +322,5 @@ The timestamp information in [EVT] represents the time when the register with [A
 
 - v1.4.1
   * Remove table of contents to avoid redundancy with doc generators.
-  * Avoid using verbatim literals.
-  * Change device naming to Host and Device.
+  * Avoid using verbatim literals in titles.
+  * Change device naming to Controller and Device.

--- a/Device.md
+++ b/Device.md
@@ -1,34 +1,10 @@
-﻿# Common Registers and Operation (Device) 1.2
+﻿<img src="./Logo/HarpLogoSmall.svg" width="200">
 
-## Document Version 1.9.0
-
-<img src="./Logo/HarpLogoSmall.svg" width="200">
-
-## Table of contents
-
-- [Common Registers and Operation (Device) 1.2](#common-registers-and-operation-device-12)
-  - [Document Version 1.9.0](#document-version-190)
-  - [Table of contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Registers](#registers)
-    - [Common Registers](#common-registers)
-    - [Operation Modes](#operation-modes)
-    - [**Table - List of available Common Registers**](#table---list-of-available-common-registers)
-      - [**`R_WHO_AM_I` (U16) – Who Am I**](#r_who_am_i-u16--who-am-i)
-      - [**`R_TIMESTAMP_SECOND` (U32) – System timestamp (seconds)**](#r_timestamp_second-u32--system-timestamp-seconds)
-      - [**`R_TIMESTAMP_MICRO` (U16) – System timestamp (microseconds)**](#r_timestamp_micro-u16--system-timestamp-microseconds)
-      - [**`R_OPERATION_CTRL` (U16) – Operation mode configuration**](#r_operation_ctrl-u16--operation-mode-configuration)
-      - [**`R_RESET_DEV` (U8) – Reset device and save non-volatile registers**](#r_reset_dev-u8--reset-device-and-save-non-volatile-registers)
-      - [**`R_DEVICE_NAME` (25 Bytes) – Device's name**](#r_device_name-25-bytes--devices-name)
-      - [**`R_SERIAL_NUMBER` (U16) – Device's serial number**](#r_serial_number-u16--devices-serial-number)
-      - [**`R_CLOCK_CONFIG` (U8) – Synchronization clock configuration**](#r_clock_config-u8--synchronization-clock-configuration)
-      - [**`R_TIMESTAMP_OFFSET` (U8) – Clock calibration offset**](#r_timestamp_offset-u8--clock-calibration-offset)
-  - [Release notes:](#release-notes)
-
+# Common Registers and Operation (Device 1.2)
 
 ## Introduction
 
-This document defines the standards that new Harp Devices should strive to follow. The goal is to create a common ground for the development and operation of Harp devices, to allow quick and easy integration of new devices into the existing ecosystem. While some registers and functionalities are not mandatory, it is strongly recommended that they are implemented or, at least, considered with compatibility in mind.
+This document defines the common set of standard functionality that new Harp `Device` hardware should aim to provide. The goal is to create a common ground for the development and operation of Harp devices, and to allow quick and easy integration of new devices into the existing ecosystem. While some registers and functionalities are not mandatory, it is strongly recommended that they are implemented or, at least, considered with compatibility in mind.
 
 ## Registers
 
@@ -433,43 +409,47 @@ When the value of this register is above 0 (zero), the device’s timestamp will
 
 ## Release notes:
 
-- V0.2
+- v0.2
     * First draft released.
 
-- V1.0
+- v1.0
 
     * R_RESET_DEV and R_DEVICE_NAME are now optional.
     * Changed Normal Mode to Standby Mode.
     * Added bit ALIVE_EN to register R_OPERATION_CTRL. This is an important feature.
     * Major release.
 
-- V1.1
+- v1.1
   * Added bit MUTE_RPL to register R_OPERATION_CTRL.
 
-- V1.2
+- v1.2
   * Corrected some wrong names.
 
-- V1.3
+- v1.3
   * Added the bit NAME_TO_DEFAULT.
 
-- V1.4
+- v1.4
   * Added the register R_SERIAL_NUMBER.
 
-- V1.5
+- v1.5
   * Added the register R_CLOCK_CONFIG.
 
-- V1.6
+- v1.6
   * Changed device naming to Controller and Peripheral.
 
-- V1.7
+- v1.7
   * Raised version to 1.2 since all the foreseen features are included at this point.
   * Added the register R_TIMESTAMP_OFFSET.
 
-- V1.8
+- v1.8
   * Replaced HARP_VERSION with CORE_VERSION.
 
-- V1.9.0
+- v1.9.0
   * Refactor documentation to markdown format.
   * Minor typo corrections.
   * Improve clarity of some sections.
   * Adopt semantic versioning.
+
+- v1.9.1
+  * Remove table of contents to avoid redundancy with doc generators.
+  * Minor improvements to clarity of introduction.

--- a/SynchronizationClock.md
+++ b/SynchronizationClock.md
@@ -1,28 +1,9 @@
-# Synchronization Clock Protocol (1.0)
-## Document Version 1.1.0
-
 <img src="./Logo/HarpLogoSmall.svg" width="200">
 
----
-
-## Table of contents
-
-- [Synchronization Clock Protocol (1.0)](#synchronization-clock-protocol-10)
-  - [Document Version 1.1.0](#document-version-110)
-  - [Table of contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Serial configuration](#serial-configuration)
-  - [Example code](#example-code)
-  - [Physical connection](#physical-connection)
-  - [Release Notes](#release-notes)
-
-
----
-
+# Synchronization Clock Protocol (1.0)
 
 ## Introduction
-The `Harp Synchronization Clock` is a bus that disseminates the current time to/across Harp devices.
-It’s a serial communication protocol that relays the time information. The last byte in each message can be used as a trigger, and allow a Device to align itself with the current `Harp` time.
+The `Harp Synchronization Clock` is a dedicated bus that disseminates the current time to/across Harp devices. It is a serial communication protocol that relays the time information. The last byte in each message can be used as a trigger, and allows a `Device`` to align itself with the current `Harp` time.
 
 ## Serial configuration
 
@@ -38,10 +19,6 @@ It’s a serial communication protocol that relays the time information. The las
 > **Important**
 >
 > To avoid unexpected behaviors, only one bit at a time should be written to register `R_RESET_DEV`.
->
-
----
-
 
 ## Example code
 
@@ -79,23 +56,21 @@ ISR(TCD0_OVF_vect, ISR_NAKED)
     }
 ```
 
----
-
-
 ## Physical connection
 
 The physical connection is made by a simple audio cable. In the same folder of this file, you can find an [example](./synchronization%20clock%20-%20physical%20connectionsch.pdf) of the sender and the receiver.
 The connector used is from `Switchcraft Inc.` with PartNo. `35RASMT2BHNTRX`.
 
----
-
 ## Release Notes
 
-- V1.0
+- v1.0
     * First version.
 
-- V1.1.0
+- v1.1.0
   * Refactor documentation to markdown format.
   * Minor typo corrections.
   * Improve clarity of some sections.
   * Adopt semantic versioning.
+
+- v1.1.1
+  * Remove table of contents to avoid redundancy with doc generators.


### PR DESCRIPTION
This PR improves the formatting and removes embedded table of contents for integration with the new docs website. DocFX generates its own TOCs automatically so it got messy with all the internal references.

The currently published prototype at [harp-tech.org](https://harp-tech.org/protocol/BinaryProtocol-8bit.html) was generated using the branch in this PR so you can check the results of the cleanup.