### PR TITLE
Add specification proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-a-new-specification.md
+++ b/.github/ISSUE_TEMPLATE/create-a-new-specification.md
@@ -1,0 +1,48 @@
+---
+name: Create a new specification
+about: For proposals that have been invited by a team member
+title: ''
+labels: proposal
+assignees: ''
+
+---
+
+<!--
+Hello, and thanks for your interest in contributing to the Harp standard! If you haven't been invited by a team member to open an issue, please instead open a discussion marked [proposal] at https://github.com/orgs/harp-tech/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal.
+
+New specification proposals should aim to fully fill out this template, at least up to and including detailed design. The sections on drawbacks, alternatives and unresolved questions may be omitted from the initial proposal.
+-->
+* [x] Proposed
+* [ ] Prototype: Not Started
+* [ ] Implementation: Not Started
+* [ ] Specification: Not Started
+
+## Summary
+
+<!-- One paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Detailed Design
+
+<!-- This is the bulk of the proposal. The Harp standard comprises multiple levels: device hardware; microcontroller firmware; high-level software interfaces; and data formats. Changes to the standard specifications might impact any or all of these levels, so please make sure you have considered the impact of your proposal on all the levels in the detailed design.
+
+Explain the design in enough detail for somebody familiar with the Harp standard to understand, and for somebody familiar with the impacted levels to implement, and include examples of how the feature will be used. Please include links to relevant parts of the existing specification to describe the changes necessary to implement this feature. An initial proposal does not need to cover all cases, but it should have enough detail to enable a team member to bring this proposal to design if they so choose. -->
+
+## Drawbacks
+
+<!-- Why should we *not* do this? -->
+
+## Alternatives
+
+<!-- What other designs have been considered? What is the impact of not doing this? -->
+
+## Unresolved Questions
+
+<!-- What parts of the design are still undecided? -->
+
+## Design Meetings
+
+<!-- Link to standard review board meetings where this proposal has been discussed. -->

--- a/.github/ISSUE_TEMPLATE/specification-proposal.md
+++ b/.github/ISSUE_TEMPLATE/specification-proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Create a new specification
 about: For proposals that have been invited by a team member
-title: ''
+title: 'Feature name'
 labels: proposal
 assignees: ''
 


### PR DESCRIPTION
This PR adds issue templates for creating specification proposals to the Harp standard. It follows a structure inspired by the [dotnet/csharplang](https://github.com/dotnet/csharplang) repository and which I used for #15.