### PR TITLE
Add specification template as a pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/specification.md
+++ b/.github/PULL_REQUEST_TEMPLATE/specification.md
@@ -1,0 +1,32 @@
+---
+name: Create a new specification
+about: For proposals that have been invited by a team member
+title: 'Feature name'
+labels: proposal
+assignees: ''
+
+---
+
+<!--
+Hello, and thanks for your interest in contributing to the Harp standard! If you haven't been invited by a team member to open a pull request, please instead open a discussion marked [proposal] at https://github.com/orgs/harp-tech/discussions/new and we'll try to give you feedback on how to get to a PR-ready proposal.
+
+New specification proposals should aim to fully fill out this template.
+-->
+
+## Summary
+
+<!-- One paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Detailed Design
+
+<!-- This is the bulk of the proposal. The Harp standard comprises multiple levels: device hardware; microcontroller firmware; high-level software interfaces; and data formats. Changes to the standard specifications might impact any or all of these levels, so please make sure you have considered the impact of your proposal on all the levels in the detailed design.
+
+Explain the design in enough detail for somebody familiar with the Harp standard to understand, and for somebody familiar with the impacted levels to implement, and include examples of how the feature will be used. Please include links to relevant parts of the existing specification to describe the changes necessary to implement this feature. -->
+
+## Relevant Discussions
+
+<!-- Link to issues or standard review board meetings where this proposal has been discussed. -->


### PR DESCRIPTION
This PR adds pull request templates for creating specification proposals to the Harp standard. Specification proposal pull-requests are meant as follow-ups to previous discussions and created issues, so the template is stripped down from the issue template defined in #24.