### PR TITLE
Clarify `Connected` behavior

### DIFF
--- a/Device.md
+++ b/Device.md
@@ -23,7 +23,7 @@ A Harp Device is expected to implement the following `Operation Modes`:
 - *`Speed Mode:`* Allows the implementation of a different and specific communication protocol. On this mode, the Harp Binary Protocol is no longer used. The specific protocol designed must implement the possibility to exit this mode.
 
 The mandatory Operation Modes are the **`Standby Mode`** and **`Active Mode`**. The **`Speed Mode`** is optional and, in many of the applications, not needed.
-Harp Devices should continuously check if the communication with the host is active and healthy. This status check will be largely dependent on the transport layer implementing the harp protocol between host and device. Thus, while each implementing must define `Connected` or `Not Connected` status, it is up to the developer to decide how to implement this status check.
+Harp Devices should continuously check if the communication with the host is active and healthy. This status check will be largely dependent on the transport layer implementing the harp protocol between host and device. Each implementation should clearly distinguish between `Connected` and `Not Connected` states, and it is up to the developer to decide how to implement this status check. When the device transitions to the `Not Connected` state, it should immediately enter `Standy Mode` and stop transmission of further event messages.
 
 As an application example, devices using USB as the transport layer, can check if the USB connection is alive by setting the DTR pin `HIGH`. Once this pin is set `LOW` it may be assumed that the host closed the connection and the device should enter `Standby Mode`.
 

--- a/Device.md
+++ b/Device.md
@@ -23,7 +23,9 @@ A Harp Device is expected to implement the following `Operation Modes`:
 - *`Speed Mode:`* Allows the implementation of a different and specific communication protocol. On this mode, the Harp Binary Protocol is no longer used. The specific protocol designed must implement the possibility to exit this mode.
 
 The mandatory Operation Modes are the **`Standby Mode`** and **`Active Mode`**. The **`Speed Mode`** is optional and, in many of the applications, not needed.
-It’s strongly recommended that a Harp Device acting as peripheral should continuously check if the communication with the host is active and healthy. If this doesn’t happen over the last 3 seconds, the Harp Device should go to Standby Mode and flush/destroy its TX buffer.
+Harp Devices should continuously check if the communication with the host is active and healthy. This status check will be largely dependent on the transport layer implementing the harp protocol between host and device. Thus, while each implementing must define `Connected` or `Not Connected` status, it is up to the developer to decide how to implement this status check.
+
+As an application example, devices using USB as the transport layer, can check if the USB connection is alive by setting the DTR pin `HIGH`. Once this pin is set `LOW` it may be assumed that the host closed the connection and the device should enter `Standby Mode`.
 
 
 ### **Table - List of available Common Registers**

--- a/Device.md
+++ b/Device.md
@@ -455,3 +455,5 @@ When the value of this register is above 0 (zero), the device’s timestamp will
 - v1.9.1
   * Remove table of contents to avoid redundancy with doc generators.
   * Minor improvements to clarity of introduction.
+- v1.9.2
+  * Clarify `Connected` behavior between host and device and add application examples.

--- a/Device.md
+++ b/Device.md
@@ -25,7 +25,7 @@ A Harp Device is expected to implement the following `Operation Modes`:
 The mandatory Operation Modes are the **`Standby Mode`** and **`Active Mode`**. The **`Speed Mode`** is optional and, in many of the applications, not needed.
 Harp Devices should continuously check if the communication with the host is active and healthy. This status check will be largely dependent on the transport layer implementing the harp protocol between host and device. Each implementation should clearly distinguish between `Connected` and `Not Connected` states, and it is up to the developer to decide how to implement this status check. When the device transitions to the `Not Connected` state, it should immediately enter `Standy Mode` and stop transmission of further event messages.
 
-As an application example, devices using USB as the transport layer, can check if the USB connection is alive by setting the DTR pin `HIGH`. Once this pin is set `LOW` it may be assumed that the host closed the connection and the device should enter `Standby Mode`.
+As an application example, devices using USB as the transport layer can poll for an active USB connection by checking that the state of the DTR pin is set to `HIGH`. Once this pin is set `LOW` it may be assumed that the host closed the connection and the device should enter `Standby Mode`. In this case, the host is responsible for setting the state of the DTR line when opening or closing a new connection.
 
 
 ### **Table - List of available Common Registers**


### PR DESCRIPTION
This PR partially addresses issue #14 by explicitly stating what is the expected definition of `connected` between device and host.

Since the harp protocol can be implemented on top of distinct transport layers, we simply define that each transport layer/implementation is responsible for defining its own way to make sure that the connection is alive. We suggest that for USB connections, the DTR pin can be leveraged. 

The immediate implication of this decision is that the C# Bonsai client will set this DTR flag high by default so that devices that can leverage this behavior will now be able to do so.