### PR TITLE
Add UID register to protocol

### DIFF
--- a/Device.md
+++ b/Device.md
@@ -48,6 +48,7 @@ As an application example, devices using USB as the transport layer can poll for
 |R\_SERIAL\_NUMBER|No|No|U16|013|b)|Unique serial number of the device|Optional|
 |R\_CLOCK\_CONFIG|No|No|U8|014|b)|Synchronization clock configuration|Optional|
 |R\_TIMESTAMP\_OFFSET|No|No|U8|015|b)|Adds an offset if user updates the Timestamp|Optional|
+|R\_UUID|No|YES|U8|016|b)|Stores an universally unique identifier (UUID) |Optional|
 
 ||a) These values are stored during factory process and are persistent, i.e., they cannot be changed by the user.<br>b) Check register notes on the specific register explanation<br>c) Only parts of the functionality is mandatory. Check register notes on the explanation.|
 | :- | :- |
@@ -324,6 +325,12 @@ gantt
 This number should be unique for each unit of the same Device ID.
 To write to this register a two-step write command is needed. First, write the value `0xFFFF`, and then the desired serial number (as a `U16`). The device will reset after the second write command is received.
 
+> **Note**
+>
+> This register is to be deprecated in the near future in favor of the `R_UUID` register. Until then, we strongly encourage the value of this register to duplicate the first two bytes of `R_UUID`.
+
+
+
 #### **`R_CLOCK_CONFIG` (U8) – Synchronization clock configuration**
 
 Address: `014`
@@ -409,6 +416,13 @@ gantt
 ```
 When the value of this register is above 0 (zero), the device’s timestamp will be offset by this amount. The register is sensitive to 500 microsecond increments. This register is non-volatile.
 
+#### **`R_UUID` (16 Bytes) – Universally Unique Identifier**
+
+Address: `016`
+
+An array of 16 bytes that should contain a UUID (Universally Unique Identifier) of the current device. This register is non-volatile and should be read-only.
+
+
 ## Release notes:
 
 - v0.2
@@ -455,5 +469,10 @@ When the value of this register is above 0 (zero), the device’s timestamp will
 - v1.9.1
   * Remove table of contents to avoid redundancy with doc generators.
   * Minor improvements to clarity of introduction.
+
 - v1.9.2
   * Clarify `Connected` behavior between host and device and add application examples.
+
+- v1.10.0
+  * Add `UUID` register
+  * Add future deprecation warning to `R_SERIAL_NUMBER` register.

--- a/Device.md
+++ b/Device.md
@@ -48,7 +48,7 @@ As an application example, devices using USB as the transport layer can poll for
 |R\_SERIAL\_NUMBER|No|No|U16|013|b)|Unique serial number of the device|Optional|
 |R\_CLOCK\_CONFIG|No|No|U8|014|b)|Synchronization clock configuration|Optional|
 |R\_TIMESTAMP\_OFFSET|No|No|U8|015|b)|Adds an offset if user updates the Timestamp|Optional|
-|R\_UUID|No|YES|U8|016|b)|Stores an universally unique identifier (UUID) |Optional|
+|R\_UID|No|YES|U8|016|b)|Stores a unique identifier (UID) |Optional|
 
 ||a) These values are stored during factory process and are persistent, i.e., they cannot be changed by the user.<br>b) Check register notes on the specific register explanation<br>c) Only parts of the functionality is mandatory. Check register notes on the explanation.|
 | :- | :- |
@@ -327,7 +327,7 @@ To write to this register a two-step write command is needed. First, write the v
 
 > **Note**
 >
-> This register is to be deprecated in the near future in favor of the `R_UUID` register. Until then, we strongly encourage the value of this register to duplicate the first two bytes of `R_UUID`.
+> This register is to be deprecated in the near future in favor of the `R_UID` register. Until then, we strongly encourage the value of this register to duplicate the first two bytes of `R_UID`. Consider that the bytes should be packed in little-endian order.
 
 
 
@@ -416,11 +416,11 @@ gantt
 ```
 When the value of this register is above 0 (zero), the device’s timestamp will be offset by this amount. The register is sensitive to 500 microsecond increments. This register is non-volatile.
 
-#### **`R_UUID` (16 Bytes) – Universally Unique Identifier**
+#### **`R_UID` (16 Bytes) – Unique Identifier**
 
 Address: `016`
 
-An array of 16 bytes that should contain a UUID (Universally Unique Identifier) of the current device. This register is non-volatile and should be read-only.
+An array of 16 bytes that should contain a (128bit) UID (Unique Identifier) of the current device. This register is non-volatile and should be read-only. The byte-order is little-endian.
 
 
 ## Release notes:
@@ -474,5 +474,5 @@ An array of 16 bytes that should contain a UUID (Universally Unique Identifier) 
   * Clarify `Connected` behavior between host and device and add application examples.
 
 - v1.10.0
-  * Add `UUID` register
+  * Add `UID` register
   * Add future deprecation warning to `R_SERIAL_NUMBER` register.

--- a/Device.md
+++ b/Device.md
@@ -327,7 +327,7 @@ To write to this register a two-step write command is needed. First, write the v
 
 > **Note**
 >
-> This register is to be deprecated in the near future in favor of the `R_UID` register. Until then, we strongly encourage the value of this register to duplicate the first two bytes of `R_UID`. Consider that the bytes should be packed in little-endian order.
+> This register is to be deprecated in the near future in favor of the `R_UID` register. Until then, we strongly encourage the value of this register to duplicate the first two bytes of `R_UID`. In this case, similarly to the harp protocol specification, the two bytes should be packed in little-endian order.
 
 
 


### PR DESCRIPTION
## Summary

This PR adds a new register to the protocol called `UID`.

## Motivation

We currently use a single U16 value to keep track of the serial numbers of devices. This is a rather small number and hardly future proof. Adhering on a pre-existing standard would make the implementation much more generic. For instance, it would allow one to co-opt pico's chip serial number (64bit) into this register.

## Detailed Design

For the sake of backwards compatibility, we will add a new register instead of modifying the current `R_SERIAL_NUMBER`.
A new register will be added with the following specs:

Name: UID
Address: 16
Format: U8[16]
Access: Read-only

A deprecation warning was also added to the protocol regarding register `R_SERIAL_NUMBER`. For now, this register will duplicate the first two bytes of `R_UID`. On the next major release, the `R_SERIAL_NUMBER` will likely be removed and only `R_UID` supported.

## Design Meetings

See further discussion in the following issues:
- #31 