### PR TITLE
Add hearbeat register

### DIFF
--- a/Device.md
+++ b/Device.md
@@ -1,4 +1,4 @@
-<img src="./assets/HarpLogo.svg" width="200">
+﻿<img src="./assets/HarpLogo.svg" width="200">
 
 # Common Registers and Operation (Device 1.2)
 
@@ -225,7 +225,7 @@ a) Standby Mode and Active Mode are mandatory. Speed Mode is optional.
 | 1          	| Speed Mode.                                                                                              	|
 | 0.1        	| A critical error occurred. Only a hardware reset or a new power up can remove the device from this Mode. 	|
 
-* **ALIVE_EN [Bit 7]:** If set to 1, the device sends an `Event` Message with the `R_TIMESTAMP_SECONDS` content each second (i.e. Heartbeat). This allows the host to check that the device is alive. Although this is an optional feature, it’s strongly recommended to be implemented.
+* **ALIVE_EN [Bit 7]:** If set to 1, the device sends an `Event` Message with the `R_HEARTBEAT` content each second. This allows the host to check the status of the device periodically. Although this is an optional feature, it’s strongly recommended to be implemented.
 
 
 
@@ -429,6 +429,59 @@ Address: `017`
 
 An array of 8 bytes that can be used to store a tag for a specific firmware version. For instance, it could be used to store the git hash of a specific release/commit. If not used, all bytes should be set to 0. The byte-order is little-endian.
 
+#### **`R_HEARTBEAT` (U16) – Heartbeat register reporting the current status of the device**
+
+Address: `018`
+
+```mermaid
+---
+displayMode: compact
+---
+gantt
+    title R_HEARTBEAT (018)
+    dateFormat X
+    axisFormat %
+
+    section Bit
+    15      :bit15, 0, 1
+    14      :bit14, after bit15  , 2
+    13      :bit13, after bit14  , 3
+    12      :bit12, after bit13  , 4
+    11      :bit11, after bit12  , 5
+    10     :bit10, after bit11  , 6
+    9      :bit9, after bit10  , 7
+    9      :bit8, after bit9  , 8
+    7      :bit7, after bit8  , 9
+    6      :bit6, after bit7  , 10
+    5      :bit5, after bit6  , 11
+    4      :bit4, after bit5  , 12
+    3      :bit3, after bit4  , 13
+    2      :bit2, after bit3  , 14
+    1      :bit1, after bit2  , 15
+    0      :bit0, after bit1  , 16
+
+    section Id
+    IS_ACTIVE      :id0, 15, 16
+    IS_ERROR_STATE      :id1, 14, 15
+    IS_SYNCHRONIZED      :id2, 13, 14
+
+    section Default
+    -      :d7, 15, 16
+    -      :d6, 14  , 15
+    -      :d5, 13  , 14
+```
+
+> **Note**
+>
+> This register is read-only and is used to provide status information about the device. The bits are set by the device and sent through a period event. If enabled (via `R_OPERATION_CTRL` bit `ALIVE_EN`), the event will be periodically emitted at a rate of 1Hz, aligned to when the `R_TIMESTAMP_SECOND` register is updated. The status of the device is given by the following bits:
+
+
+* **IS_ACTIVE [Bit 0]:** If 1, the device will be in Active Mode. Any other modes will be coded as 0. (See `R_OPERATION_CTRL` bit `OP_MODE` for more information).
+
+* **IS_ERROR_STATE [Bit 1]:** This bit will be read as 1 if the device is in an error state. The implementation of an error state is expected largely implementation specific, however this state should be entered when the device is in a state where it cannot recover without manual intervention.
+
+* **IS_SYNCHRONIZED [Bit 3]:** If set to 1, the device is synchronized with the Harp Synchronization Clock. If the device is a clock generator (see `R_CLOCK_CONFIG` bit `CLK_GEN`), by definition, this bit will always be set to 1.
+
 
 ## Release notes:
 
@@ -488,4 +541,5 @@ An array of 8 bytes that can be used to store a tag for a specific firmware vers
   * Add new `Tag` register.
 
 - v1.12.0
+  * Add heartbeat register providing status information
   * Fix typo in `OPERATION_CTRL` register data type (U16 -> U8)

--- a/Device.md
+++ b/Device.md
@@ -444,30 +444,19 @@ gantt
     axisFormat %
 
     section Bit
-    15      :bit15, 0, 1
-    14      :bit14, after bit15  , 2
-    13      :bit13, after bit14  , 3
-    12      :bit12, after bit13  , 4
-    11      :bit11, after bit12  , 5
-    10     :bit10, after bit11  , 6
-    9      :bit9, after bit10  , 7
-    9      :bit8, after bit9  , 8
-    7      :bit7, after bit8  , 9
-    6      :bit6, after bit7  , 10
-    5      :bit5, after bit6  , 11
-    4      :bit4, after bit5  , 12
-    3      :bit3, after bit4  , 13
-    2      :bit2, after bit3  , 14
-    1      :bit1, after bit2  , 15
-    0      :bit0, after bit1  , 16
+    15-2      :reserved, 0, 1
+    1         :bit1, 1, 2
+    0         :bit0, 2, 3
 
     section Id
-    IS_ACTIVE      :id0, 15, 16
-    IS_SYNCHRONIZED      :id1, 14, 15
+    -               :idr, 0, 1
+    IS_ACTIVE       :id0, 1, 2
+    IS_SYNCHRONIZED :id1, 2, 3
 
     section Default
-    -      :d7, 15, 16
-    -      :d6, 14  , 15
+    -      :dr, 0, 1
+    -      :d7, 1, 2
+    -      :d6, 2, 3
 ```
 
 > **Note**

--- a/Device.md
+++ b/Device.md
@@ -480,7 +480,7 @@ The status of the device is given by the following bits:
 
 * **IS_STANDBY [Bit 0]:** If 1, the device will be in Standby Mode. Any other modes will be coded as 0. (See `R_OPERATION_CTRL` bit `OP_MODE` for more information).
 
-* **IS_SYNCHRONIZED [Bit 1]:** If set to 1, the device is synchronized with a Harp Synchronization Clock. If the device is a clock generator (see `R_CLOCK_CONFIG` bit `CLK_GEN`), by definition, this bit will always be set to 1.
+* **IS_SYNCHRONIZED [Bit 1]:** If set to 1, the device is synchronized with an external Harp clock generator. If the device is itself a clock generator (see `R_CLOCK_CONFIG` bit `CLK_GEN`), by definition, this bit will always be set to 1.
 
 
 ## Release notes:

--- a/Device.md
+++ b/Device.md
@@ -50,6 +50,7 @@ As an application example, devices using USB as the transport layer can poll for
 |R\_TIMESTAMP\_OFFSET|No|No|U8|015|b)|Adds an offset if user updates the Timestamp|Optional|
 |R\_UID|No|Yes|U8|016|b)|Stores a unique identifier (UID) |Optional|
 |R\_TAG|-|Yes|U8|017|b)|Firmware tag|Optional|
+|R\_HEARTBEAT|Yes|Yes|U16|018|b)|Provides information about the state of the device|Yes|
 
 ||a) These values are stored during factory process and are persistent, i.e., they cannot be changed by the user.<br>b) Check register notes on the specific register explanation<br>c) Only parts of the functionality is mandatory. Check register notes on the explanation.|
 | :- | :- |
@@ -225,7 +226,7 @@ a) Standby Mode and Active Mode are mandatory. Speed Mode is optional.
 | 1          	| Speed Mode.                                                                                              	|
 | 0.1        	| A critical error occurred. Only a hardware reset or a new power up can remove the device from this Mode. 	|
 
-* **ALIVE_EN [Bit 7]:** If set to 1, the device sends an `Event` Message with the `R_HEARTBEAT` content each second. This allows the host to check the status of the device periodically. Although this is an optional feature, it’s strongly recommended to be implemented.
+* **ALIVE_EN [Bit 7]:** If set to 1, the device sends an `Event` Message with the `R_HEARTBEAT` content each second. This allows the host to check the status of the device periodically. This is a required feature.
 
 
 
@@ -462,18 +463,16 @@ gantt
 
     section Id
     IS_ACTIVE      :id0, 15, 16
-    IS_ERROR_STATE      :id1, 14, 15
-    IS_SYNCHRONIZED      :id2, 13, 14
+    IS_SYNCHRONIZED      :id1, 14, 15
 
     section Default
     -      :d7, 15, 16
     -      :d6, 14  , 15
-    -      :d5, 13  , 14
 ```
 
 > **Note**
 >
-> This register is read-only and is used to provide status information about the device. The bits are set by the device and sent through a period event. If enabled (via `R_OPERATION_CTRL` bit `ALIVE_EN`), the event will be periodically emitted at a rate of 1Hz, triggered by updates to the `R_TIMESTAMP_SECOND` register. 
+> This register is read-only and is used to provide status information about the device. The bits are set by the device and sent through a period event. If enabled (via `R_OPERATION_CTRL` bit `ALIVE_EN`), the event will be periodically emitted at a rate of 1Hz, triggered by updates to the `R_TIMESTAMP_SECOND` register.
 
 
 The status of the device is given by the following bits:
@@ -481,9 +480,7 @@ The status of the device is given by the following bits:
 
 * **IS_STANDBY [Bit 0]:** If 1, the device will be in Standby Mode. Any other modes will be coded as 0. (See `R_OPERATION_CTRL` bit `OP_MODE` for more information).
 
-* **IS_ERROR_STATE [Bit 1]:** This bit will be read as 1 if the device is in an error state. The implementation of an error state is expected largely implementation specific, however this state should be entered when the device is in a state where it cannot recover without manual intervention.
-
-* **IS_SYNCHRONIZED [Bit 3]:** If set to 1, the device is synchronized with the Harp Synchronization Clock. If the device is a clock generator (see `R_CLOCK_CONFIG` bit `CLK_GEN`), by definition, this bit will always be set to 1.
+* **IS_SYNCHRONIZED [Bit 1]:** If set to 1, the device is synchronized with a Harp Synchronization Clock. If the device is a clock generator (see `R_CLOCK_CONFIG` bit `CLK_GEN`), by definition, this bit will always be set to 1.
 
 
 ## Release notes:

--- a/Device.md
+++ b/Device.md
@@ -473,10 +473,13 @@ gantt
 
 > **Note**
 >
-> This register is read-only and is used to provide status information about the device. The bits are set by the device and sent through a period event. If enabled (via `R_OPERATION_CTRL` bit `ALIVE_EN`), the event will be periodically emitted at a rate of 1Hz, aligned to when the `R_TIMESTAMP_SECOND` register is updated. The status of the device is given by the following bits:
+> This register is read-only and is used to provide status information about the device. The bits are set by the device and sent through a period event. If enabled (via `R_OPERATION_CTRL` bit `ALIVE_EN`), the event will be periodically emitted at a rate of 1Hz, triggered by updates to the `R_TIMESTAMP_SECOND` register. 
 
 
-* **IS_ACTIVE [Bit 0]:** If 1, the device will be in Active Mode. Any other modes will be coded as 0. (See `R_OPERATION_CTRL` bit `OP_MODE` for more information).
+The status of the device is given by the following bits:
+
+
+* **IS_STANDBY [Bit 0]:** If 1, the device will be in Standby Mode. Any other modes will be coded as 0. (See `R_OPERATION_CTRL` bit `OP_MODE` for more information).
 
 * **IS_ERROR_STATE [Bit 1]:** This bit will be read as 1 if the device is in an error state. The implementation of an error state is expected largely implementation specific, however this state should be entered when the device is in a state where it cannot recover without manual intervention.
 

--- a/Device.md
+++ b/Device.md
@@ -1,4 +1,4 @@
-﻿<img src="./assets/HarpLogo.svg" width="200">
+<img src="./assets/HarpLogo.svg" width="200">
 
 # Common Registers and Operation (Device 1.2)
 
@@ -145,7 +145,7 @@ gantt
 ```
 
 
-#### **`R_OPERATION_CTRL` (U16) – Operation mode configuration**
+#### **`R_OPERATION_CTRL` (U8) – Operation mode configuration**
 
 Address: `010`
 
@@ -486,3 +486,6 @@ An array of 8 bytes that can be used to store a tag for a specific firmware vers
 
 - v1.11.0
   * Add new `Tag` register.
+
+- v1.12.0
+  * Fix typo in `OPERATION_CTRL` register data type (U16 -> U8)


### PR DESCRIPTION
## Summary

This PR adds a new register to the protocol called `HEARTBEAT`.

## Motivation

We want to be able to periodically check the status of the device. Including synchronization, mode and error status.

## Detailed Design

We will add a new register with the following specs:

Name: Heartbeat
Address: 18
Format: U16
Access: Read-only


For now, only 2 bits will be implemented:
 - IS_STANDBY
 - IS_SYNCHRONIZED

The other 14 bits will remain free for future status bits.

More information is available in the PR.


## Design Meetings

See further discussion in the following issues:
- #11 , #32 
- See #63 for a spin off discussion