### PR TITLE
Reserve whoami 1404 for WhiteRabbit device

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -161,3 +161,9 @@ devices:
     copyright: AllenNeuralDynamics
     repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish
     projectUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish
+ 1404:
+    name: WhiteRabbit
+    authors: AllenNeuralDynamics
+    copyright: AllenNeuralDynamics
+    repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.white-rabbit
+    projectUrl: https://github.com/AllenNeuralDynamics/harp.device.white-rabbit


### PR DESCRIPTION
This PR attempts to reserve a new whoami (1404) for a new AIND device codename: WhiteRabbit.