### PR TITLE
Fix indentation in WhoAmI file

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -161,7 +161,7 @@ devices:
     copyright: AllenNeuralDynamics
     repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish
     projectUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish
- 1404:
+  1404:
     name: WhiteRabbit
     authors: AllenNeuralDynamics
     copyright: AllenNeuralDynamics


### PR DESCRIPTION
Fixing a bug introduced in #50 that prevents the action from running. In the future, we should probably add some test that runs on each PR to ensure this does not happen again.