### PR TITLE
Add core register schema with protocol version

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -6,7 +6,8 @@
         {
             "properties": {
                 "protocolVersion": {
-                    "description": "Specifies the semantic version of the device protocol.",
+                    "description": "Specifies the version of the device protocol.",
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
                     "type": "string"
                 }
             },

--- a/schema/core.json
+++ b/schema/core.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://harp-tech.org/draft-03/schema/core.json",
+    "type": "object",
+    "allOf": [
+        {
+            "properties": {
+                "protocolVersion": {
+                    "description": "Specifies the semantic version of the device protocol.",
+                    "type": "string"
+                }
+            },
+            "required": ["protocolVersion"]
+        },
+        { "$ref": "registers.json" }
+    ]
+}

--- a/schema/core.yml
+++ b/schema/core.yml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=registers.json
+# yaml-language-server: $schema=core.json
+protocolVersion: "1.13"
 registers:
   WhoAmI:
     address: 0

--- a/schema/device.json
+++ b/schema/device.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/draft-02/schema/device.json",
+    "$id": "https://harp-tech.org/draft-03/schema/device.json",
     "type": "object",
     "allOf": [
         {
@@ -31,6 +31,6 @@
             },
             "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets"]
         },
-        { "$ref": "registers.json" }
+        { "$ref": "core.json" }
     ]
 }

--- a/schema/device.json
+++ b/schema/device.json
@@ -14,11 +14,13 @@
                     "type": "integer"
                 },
                 "firmwareVersion": {
-                    "description": "Specifies the semantic version of the device firmware.",
+                    "description": "Specifies the version of the device firmware.",
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
                     "type": "string"
                 },
                 "hardwareTargets": {
-                    "description": "Specifies the semantic version of the device hardware.",
+                    "description": "Specifies the version of the device hardware.",
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
                     "type": "string"
                 },
                 "registers": {

--- a/schema/ios.json
+++ b/schema/ios.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/draft-02/schema/ios.json",
+    "$id": "https://harp-tech.org/draft-03/schema/ios.json",
     "type": "object",
     "description": "Specifies the IO pin configuration used to automatically generate firmware.",
     "additionalProperties": {

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/draft-02/schema/registers.json",
+    "$id": "https://harp-tech.org/draft-03/schema/registers.json",
     "type": "object",
     "properties": {
         "registers": {


### PR DESCRIPTION
Following discussions in #22, this PR introduces a core register schema with a `protocolVersion` field specifying the minimum semantic version mandating a given set of common registers.

The new JSON schema is named `core.json` and is to be used by both the common register metadata file and each of the `device.yml` files.

The common register metadata file is also renamed to `core.yml` to avoid the unusual terminology of "common". In Harp parlance, the "core" is always what we talk about when discussing requirements for hardware devices. There is no direct reference to this metadata file other than from the generator and analysis packages, which will be themselves updated in the near future to embed the new `core.yml`. Since these packages distribute their own snapshots, changing and renaming this file is not expected to be breaking.

Also added regex validation patterns for all version strings, adapted from semantic versioning with only a major and minor version component: `^(0|[1-9]\\d*)\.(0|[1-9]\d*)$`

Fixes #22 
Fixes #65 