### PR TITLE
Reserve WhoAmI for ValveController harp device

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -181,3 +181,9 @@ devices:
     copyright: AllenNeuralDynamics
     repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.environment-sensor
     projectUrl: https://github.com/AllenNeuralDynamics/harp.device.environment-sensor
+  1406:
+    name: ValveController
+    authors: AllenNeuralDynamics
+    copyright: AllenNeuralDynamics
+    repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.valve-controller
+    projectUrl: https://github.com/AllenNeuralDynamics/harp.device.valve-controller


### PR DESCRIPTION
This PR adds a new board to the list of harp devices. 
Briefly, this board:

- Is built on top of the pico harp core;
- Can power (12-24V) and control 16 solenoid valves via digital outputs.

Further details can be obtained from the project's repository (https://github.com/AllenNeuralDynamics/harp.device.valve-controller) 