### PR TITLE
Add deprecated field to register schema

### DIFF
--- a/schema/registers.json
+++ b/schema/registers.json
@@ -168,6 +168,10 @@
                     "type": "string",
                     "enum": ["public", "private"]
                 },
+                "deprecated": {
+                    "description": "Specifies whether the register function is deprecated.",
+                    "type": "boolean"
+                },
                 "volatile": {
                     "description": "Specifies whether register values can be saved in non-volatile memory.",
                     "type": "boolean"


### PR DESCRIPTION
This PR adds the "deprecated" field to the register schema. This feature follows PR #150 that explicitly deprecates core registers from the Device specification.