### PR TITLE
Add length attribute to payload member

### DIFF
--- a/schema/registers.json
+++ b/schema/registers.json
@@ -113,8 +113,13 @@
                     "type": "integer"
                 },
                 "offset": {
-                    "description": "Specifies the payload array offset where this payload member is stored.",
+                    "description": "Specifies the zero-based index at which encoding of this payload member starts.",
                     "type": "integer"
+                },
+                "length": {
+                    "description": "Specifies the number of elements used to encode this payload member.",
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "description": {
                     "description": "Specifies a summary description of the payload member.",


### PR DESCRIPTION
This allows encoding heterogeneous payload fields across multiple elements, for example to compose a single U32 out of multiple U8 values, or to specify the length of a string member, which is required for fully resolving #40 for fields with different sizes.

See https://github.com/harp-tech/reflex-generator/pull/87 for application examples.